### PR TITLE
[병운] [Err Handling] filtering wrong input

### DIFF
--- a/TeamB_SSD/main.cpp
+++ b/TeamB_SSD/main.cpp
@@ -11,6 +11,25 @@
 #include "VirtualSSD.cpp"
 #include <cstdint>
 
+bool isValidHex(const char* str) {
+  if (strncmp(str, "0x", 2) != 0) {
+    return false;
+  }
+
+  size_t len = strlen(str);
+  if (len != 10) {
+    return false;
+  }
+
+  for (size_t i = 2; i < len; ++i) {
+    if (!isxdigit(str[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 int main(int argc, char* argv[]) {
 #ifdef _DEBUG
   testing::InitGoogleTest();
@@ -30,6 +49,11 @@ int main(int argc, char* argv[]) {
   if (c == 'W') {
     if (argc != 4) {
       std::cerr << "For 'W' mode, provide 2 arguments: <int> <hexadecimal>" << std::endl;
+      return 1;
+    }
+
+    if (!isValidHex(argv[3])) {
+      std::cerr << "Invalid input. Please enter a valid 8-digit hexadecimal value in the form 0xXXXXXXXX.\n";
       return 1;
     }
 

--- a/TeamB_SSD/main.cpp
+++ b/TeamB_SSD/main.cpp
@@ -12,7 +12,11 @@
 #include <cstdint>
 
 bool isValidHex(const char* str) {
-  if (strncmp(str, "0x", 2) != 0) {
+  if (!strncmp(str, "0X", 2)) {
+    return false;
+  }
+
+  if (strncmp(str, "0x", 2)) {
     return false;
   }
 
@@ -58,8 +62,6 @@ int main(int argc, char* argv[]) {
     }
 
     uint32_t hexValue = std::strtoul(argv[3], nullptr, 16);
-
-    std::cout << "Write Mode: num = " << num << ", hexValue = 0x" << std::hex << hexValue << std::endl;
 
     ssd.executeCommand(std::make_shared<WriteCommand>(ssd, num, hexValue));
 


### PR DESCRIPTION
## 📌 PR 내용 요약
- 8자리가 아니거나 0x0~0xF 가 아닌수를 입력으로 들어왔을 시 에러처리

## 🛠️ 주요 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

## 🧪 테스트 방법

User@DESKTOP-5FBE16T MINGW64 ~/source/repos/CRA_TeamB_Project/x64/Release (error_handle_2)
$ ./ssd.exe W 2 0x23
Invalid input. Please enter a valid 8-digit hexadecimal value in the form 0xXXXXXXXX.

User@DESKTOP-5FBE16T MINGW64 ~/source/repos/CRA_TeamB_Project/x64/Release (error_handle_2)
$

## ⚠️ 참고 사항
- 리뷰할 때 주의 깊게 봐줬으면 하는 부분
- 관련된 이슈나 PR 있으면 여기에 링크
