### PR TITLE
[화영] SSD에 Erase 기능 추가

### DIFF
--- a/TeamB_SSD/SSD_Test.cpp
+++ b/TeamB_SSD/SSD_Test.cpp
@@ -7,28 +7,29 @@ using namespace testing;
 class CommandFixture : public Test {
  protected:
   VirtualSSD ssd;
-  std::shared_ptr<ICommand> makeCommand(char cmd, int lba, uint32_t value) {
+  std::shared_ptr<ICommand> makeCommand(char cmd, int lba, uint32_t value, int size) {
     std::shared_ptr<ICommand> ret;
     if (cmd == 'W') {
       ret = std::make_shared<WriteCommand>(ssd, lba, value);
-    }
-    else if (cmd == 'R') {
+    } else if (cmd == 'R') {
       ret = std::make_shared<ReadCommand>(ssd, lba);
-    }
-    else if (cmd == 'F') {
+    } else if (cmd == 'F') {
       ret = std::make_shared<FlushCommand>(ssd);
+    } else if (cmd == 'E') {
+      ret = std::make_shared<EraseCommand>(ssd, lba, size);
     }
     return ret;
   }
 
-  void executeAndExpectTRUE(char cmd, int lba = 0, uint32_t value = 0) {
-    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value);
+  void executeAndExpectTRUE(char cmd, int lba = 0, uint32_t value = 0,
+                            int size = 0) {
+    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value, size);
     bool ret = ssd.executeCommand(Command);
     EXPECT_TRUE(ret);
   }
 
-  void expectCommandFALSE(char cmd, int lba, uint32_t value) {
-    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value);
+  void expectCommandFALSE(char cmd, int lba, uint32_t value, int size = 0) {
+    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value, size);
     bool ret = ssd.executeCommand(Command);
     EXPECT_FALSE(ret);
   }
@@ -37,26 +38,30 @@ class CommandFixture : public Test {
 TEST_F(CommandFixture, basic_SSD_test_Write_1) {
   executeAndExpectTRUE('W', 3, 0xAAAABBBB);
 }
-
-TEST_F(CommandFixture, basic_SSD_test_Write_2) {
-  executeAndExpectTRUE('W', 3, 0xAAAABBBB);
-  executeAndExpectTRUE('W', 97, 0x1234ABCD);
-}
-
-TEST_F(CommandFixture, basic_SSD_test_Read_3_TRUE)  
-{
-  executeAndExpectTRUE('R', 3, 0xAAAABBBB);
-}
-
-TEST_F(CommandFixture, basic_SSD_test_Read_3_OutOfRange) {
-  expectCommandFALSE('R', 103, 0x00000000);
-}
-
- TEST_F(CommandFixture, basic_SSD_test_Write_Wrong_lba_index) {
-   expectCommandFALSE('W', 102, 0xAAAABBBB);
- }
-
- TEST_F(CommandFixture, basic_SSD_test_Flush)
- {
-   executeAndExpectTRUE('F');
- }
+//
+//TEST_F(CommandFixture, basic_SSD_test_Write_2) {
+//  executeAndExpectTRUE('W', 3, 0xAAAABBBB);
+//  executeAndExpectTRUE('W', 97, 0x1234ABCD);
+//}
+//
+//TEST_F(CommandFixture, basic_SSD_test_Read_3_TRUE) {
+//  executeAndExpectTRUE('R', 3, 0xAAAABBBB);
+//}
+//
+//TEST_F(CommandFixture, basic_SSD_test_Read_3_OutOfRange) {
+//  expectCommandFALSE('R', 103, 0x00000000);
+//}
+//
+//TEST_F(CommandFixture, basic_SSD_test_Write_Wrong_lba_index) {
+//  expectCommandFALSE('W', 102, 0xAAAABBBB);
+//}
+//
+//TEST_F(CommandFixture, basic_SSD_test_Flush) { executeAndExpectTRUE('F'); }
+//
+//TEST_F(CommandFixture, basic_SSD_test_Erase_0_10) {
+//  executeAndExpectTRUE('E', 0, DEFAULT_VALUE, 10);
+//}
+//
+//TEST_F(CommandFixture, basic_SSD_test_Erase_100_10) {
+//  expectCommandFALSE('E', 100, DEFAULT_VALUE, 10);
+//}

--- a/TeamB_SSD/SSD_Test.cpp
+++ b/TeamB_SSD/SSD_Test.cpp
@@ -7,7 +7,7 @@ using namespace testing;
 class CommandFixture : public Test {
  protected:
   VirtualSSD ssd;
-  std::shared_ptr<ICommand> makeCommand(char cmd, int lba, uint32_t value, int size) {
+  std::shared_ptr<ICommand> makeCommand(char cmd, int lba, uint32_t value) {
     std::shared_ptr<ICommand> ret;
     if (cmd == 'W') {
       ret = std::make_shared<WriteCommand>(ssd, lba, value);
@@ -16,20 +16,19 @@ class CommandFixture : public Test {
     } else if (cmd == 'F') {
       ret = std::make_shared<FlushCommand>(ssd);
     } else if (cmd == 'E') {
-      ret = std::make_shared<EraseCommand>(ssd, lba, size);
+      ret = std::make_shared<EraseCommand>(ssd, lba, value);
     }
     return ret;
   }
 
-  void executeAndExpectTRUE(char cmd, int lba = 0, uint32_t value = 0,
-                            int size = 0) {
-    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value, size);
+  void executeAndExpectTRUE(char cmd, int lba = 0, uint32_t value = 0) {
+    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value);
     bool ret = ssd.executeCommand(Command);
     EXPECT_TRUE(ret);
   }
 
-  void expectCommandFALSE(char cmd, int lba, uint32_t value, int size = 0) {
-    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value, size);
+  void expectCommandFALSE(char cmd, int lba, uint32_t value) {
+    std::shared_ptr<ICommand> Command = makeCommand(cmd, lba, value);
     bool ret = ssd.executeCommand(Command);
     EXPECT_FALSE(ret);
   }
@@ -38,30 +37,34 @@ class CommandFixture : public Test {
 TEST_F(CommandFixture, basic_SSD_test_Write_1) {
   executeAndExpectTRUE('W', 3, 0xAAAABBBB);
 }
-//
-//TEST_F(CommandFixture, basic_SSD_test_Write_2) {
-//  executeAndExpectTRUE('W', 3, 0xAAAABBBB);
-//  executeAndExpectTRUE('W', 97, 0x1234ABCD);
-//}
-//
-//TEST_F(CommandFixture, basic_SSD_test_Read_3_TRUE) {
-//  executeAndExpectTRUE('R', 3, 0xAAAABBBB);
-//}
-//
-//TEST_F(CommandFixture, basic_SSD_test_Read_3_OutOfRange) {
-//  expectCommandFALSE('R', 103, 0x00000000);
-//}
-//
-//TEST_F(CommandFixture, basic_SSD_test_Write_Wrong_lba_index) {
-//  expectCommandFALSE('W', 102, 0xAAAABBBB);
-//}
-//
-//TEST_F(CommandFixture, basic_SSD_test_Flush) { executeAndExpectTRUE('F'); }
-//
-//TEST_F(CommandFixture, basic_SSD_test_Erase_0_10) {
-//  executeAndExpectTRUE('E', 0, DEFAULT_VALUE, 10);
-//}
-//
-//TEST_F(CommandFixture, basic_SSD_test_Erase_100_10) {
-//  expectCommandFALSE('E', 100, DEFAULT_VALUE, 10);
-//}
+
+TEST_F(CommandFixture, basic_SSD_test_Write_2) {
+  executeAndExpectTRUE('W', 3, 0xAAAABBBB);
+  executeAndExpectTRUE('W', 97, 0x1234ABCD);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Read_3_TRUE) {
+  executeAndExpectTRUE('R', 3, 0xAAAABBBB);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Read_3_OutOfRange) {
+  expectCommandFALSE('R', 103, 0x00000000);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Write_Wrong_lba_index) {
+  expectCommandFALSE('W', 102, 0xAAAABBBB);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Flush) { executeAndExpectTRUE('F'); }
+
+TEST_F(CommandFixture, basic_SSD_test_Erase_0_10) {
+  executeAndExpectTRUE('E', 0, 10);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Erase_95_10) {
+  executeAndExpectTRUE('E', 95, 10);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Erase_100_10) {
+  expectCommandFALSE('E', 100, 10);
+}

--- a/TeamB_SSD/TeamB_SSD.vcxproj
+++ b/TeamB_SSD/TeamB_SSD.vcxproj
@@ -142,6 +142,9 @@
     <ClCompile Include="SSD_Test.cpp" />
     <ClCompile Include="VirtualSSD.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="define.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\gmock.1.11.0\build\native\gmock.targets" Condition="Exists('..\packages\gmock.1.11.0\build\native\gmock.targets')" />

--- a/TeamB_SSD/TeamB_SSD.vcxproj.filters
+++ b/TeamB_SSD/TeamB_SSD.vcxproj.filters
@@ -32,4 +32,9 @@
       <Filter>리소스 파일\test</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="define.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/TeamB_SSD/VirtualSSD.cpp
+++ b/TeamB_SSD/VirtualSSD.cpp
@@ -1,33 +1,36 @@
+#include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <cstdint>
+
+#include "define.h"
 
 class VirtualSSD;
 
 class ICommand {
-public:
+ public:
   virtual ~ICommand() = default;
   virtual bool execute() = 0;
 
-protected:
+ protected:
   VirtualSSD& ssd;
 
   ICommand(VirtualSSD& ssd) : ssd(ssd) {}
 };
 
 class VirtualSSD {
-public:
+ public:
   static constexpr const char* ERROR = "ERROR";
   static constexpr const char* INVALID = "INVALID";
   static constexpr const char* NULL_VALUE = "0x00000000";
   static constexpr const int MAX_RANGE_NUM = 100;
 
-  VirtualSSD(const std::string& nand = "ssd_nand.txt", const std::string& out = "ssd_output.txt")
-    : nand_file(nand), out_file(out) {
+  VirtualSSD(const std::string& nand = "ssd_nand.txt",
+             const std::string& out = "ssd_output.txt")
+      : nand_file(nand), out_file(out) {
     for (int i = 0; i < MAX_RANGE_NUM; ++i) {
       storage[i] = 0;
     }
@@ -38,13 +41,9 @@ public:
     return command->execute();
   }
 
-  void setData(int lba, uint32_t data) {
-    storage[lba] = data;
-  }
+  void setData(int lba, uint32_t data) { storage[lba] = data; }
 
-  uint32_t getData(int lba) {
-    return storage[lba];
-  }
+  uint32_t getData(int lba) { return storage[lba]; }
 
   bool saveStorageToFile() {
     std::ofstream outFile(nand_file, std::ios::trunc);
@@ -53,13 +52,12 @@ public:
       for (int lba = 0; lba < MAX_RANGE_NUM; ++lba) {
         if (storage[lba]) {
           outFile << std::dec << lba << " 0x" << std::uppercase << std::hex
-            << std::setw(8) << std::setfill('0') << storage[lba]
-            << std::endl;
+                  << std::setw(8) << std::setfill('0') << storage[lba]
+                  << std::endl;
         }
       }
       outFile.close();
-    }
-    else {
+    } else {
       std::cout << "Error opening file!" << std::endl;
       return false;
     }
@@ -103,17 +101,16 @@ public:
     return false;
   }
 
-private:
+ private:
   uint32_t storage[MAX_RANGE_NUM];
   const std::string nand_file;
   const std::string out_file;
 };
 
 class WriteCommand : public ICommand {
-public:
+ public:
   WriteCommand(VirtualSSD& ssd, int lba, uint32_t data)
-    : ICommand(ssd), lba(lba), data(data) {
-  }
+      : ICommand(ssd), lba(lba), data(data) {}
 
   bool execute() override {
     if (ssd.isOutOfRange(lba)) return false;
@@ -122,37 +119,71 @@ public:
     return ssd.saveStorageToFile();
   }
 
-private:
+ private:
   int lba;
   uint32_t data;
 };
 
 class ReadCommand : public ICommand {
-public:
-  ReadCommand(VirtualSSD& ssd, int lba)
-    : ICommand(ssd), lba(lba) {
-  }
+ public:
+  ReadCommand(VirtualSSD& ssd, int lba) : ICommand(ssd), lba(lba) {}
 
   bool execute() override {
     if (ssd.isOutOfRange(lba)) return false;
 
     std::stringstream ss;
     ss << "LBA " << lba << " 0x" << std::setfill('0') << std::setw(8)
-      << std::hex << std::uppercase << ssd.getData(lba);
+       << std::hex << std::uppercase << ssd.getData(lba);
 
-    return  ssd.saveOutputToFile(ss.str());
+    return ssd.saveOutputToFile(ss.str());
   }
-private:
+
+ private:
   int lba;
 };
 
 class FlushCommand : public ICommand {
-public:
-  FlushCommand(VirtualSSD& ssd)
-    : ICommand(ssd) {
-  }
+ public:
+  FlushCommand(VirtualSSD& ssd) : ICommand(ssd) {}
+
+  bool execute() override { return ssd.saveStorageToFile(); }
+};
+
+class EraseCommand : public ICommand {
+ public:
+  EraseCommand(VirtualSSD& ssd, int lba, int size) : ICommand(ssd), lba(lba), size(size) {}
 
   bool execute() override {
-    return ssd.saveStorageToFile();
+    // 범위 벗어나면 ERROR 남긴다.
+    if (ssd.isOutOfRange(lba)) {
+      ssd.saveOutputToFile(ERROR);
+      return false;
+    }
+
+    // size 가 0 보다 커야 한다.
+    if (size <= 0) {
+      ssd.saveOutputToFile(ERROR_SIZE);
+      return false;
+    }
+
+    // lba 부터 size 까지
+    for (int startLBA = lba; startLBA < lba + size; startLBA++) {
+      // 실행 도중 lba 값이 범위를 넘어가면 종료한다.
+      if (ssd.isOutOfRange(startLBA)) {
+        // 변경된 값 저장하고 종료
+        ssd.saveStorageToFile();
+        ssd.saveOutputToFile(ERROR_OUT_OF_RANGE);
+        return false;
+      }
+      ssd.setData(startLBA, DEFAULT_VALUE);
+    }
+
+    // 변경된 값 저장하고 종료
+    ssd.saveStorageToFile();
+    return true;
   }
+
+ private:
+  int lba;
+  int size;
 };

--- a/TeamB_SSD/define.h
+++ b/TeamB_SSD/define.h
@@ -1,0 +1,9 @@
+#pragma once
+
+static constexpr const char* ERROR = "ERROR";
+static constexpr const char* ERROR_SIZE = "ERROR_SIZE";
+static constexpr const char* ERROR_OUT_OF_RANGE = "ERROR_OUT_OF_RANGE";
+
+static constexpr const int MAX_RANGE_NUM = 100;
+static constexpr const int DEFAULT_VALUE = 0x00000000;
+#pragma once

--- a/TeamB_SSD/main.cpp
+++ b/TeamB_SSD/main.cpp
@@ -117,13 +117,13 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  if (mode == 'W' || mode == 'w') {
+  if (mode == 'W') {
     return processWrite(num, hexStr, ssd) ? 0 : 1;
-  } else if (mode == 'R' || mode == 'r') {
+  } else if (mode == 'R') {
     return processRead(num, ssd);
-  } else if (mode == 'F' || mode == 'f') {
+  } else if (mode == 'F') {
     return flushRead(ssd);
-  } else if (mode == 'E' || mode == 'e') {
+  } else if (mode == 'E') {
     processErase(num, size, ssd);
     return 0;
   }


### PR DESCRIPTION
## 📌 PR 내용 요약
-  SSD에 Erase 기능 추가
- 
## 🛠️ 주요 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- main.cpp, VirtualSSD.cpp, 파일에 erase 호출 되는 부분 추가 
     -> lba 범위기 벗어나면 ERROR 에러 ssd_output.txt 파일이 남김.
     -> size 가 1보다 작은 경우 ERROR_SIZE 에러 ssd_output.txt 파일에 남김. 
     -> 값을 지우는 동안 범위가 벗어나는 경우 ERROR_OUT_OF_RANGE 에러 ssd_output.txt 파일에 남김.
       ( 95 부터 10개일때 99까지 진행하고 ERROR_OUT_OF_RANGE  남기고 종료 )
- SSD_Test.cpp 에 erase 테스트 부분 추가. 
- define.h 에 자주 사용되는 변수 static 으로 추가.

## 🧪 테스트 방법

## ⚠️ 참고 사항
