### PR TITLE
[윤제] Erase 기능 구현 및 TC 추가

### DIFF
--- a/TeamB_Shell/ShellTest.cpp
+++ b/TeamB_Shell/ShellTest.cpp
@@ -22,6 +22,9 @@ void ShellTest::executeCommand(const std::string &input) {
   } else if (command == "fullread") {
     if (!excuteFullRead(iss)) std::cout << invalid_command;
     return;
+  } else if (command == "erase") {
+    if (!excuteErase(iss)) std::cout << invalid_command;
+    return;
   } else if (command == "flush") {
     if (!excuteFlush(iss)) std::cout << invalid_command;
     return;
@@ -110,6 +113,35 @@ bool ShellTest::excuteFullRead(std::istringstream &iss) {
   return true;
 }
 
+bool ShellTest::excuteErase(std::istringstream &iss) {
+  std::string lbaStr, sizeStr, trashStr;
+  iss >> lbaStr >> sizeStr >> trashStr;
+
+  if (!checkValidArgument(trashStr)) return false;
+  if (!checkValidLba(lbaStr)) return false;
+  if (!checkValidSize(sizeStr)) {
+    return false;
+  }
+
+  long long sizeNum = std::stoll(sizeStr);
+  int lbaNum = std::stoi(lbaStr);
+  while (sizeNum > 0) {
+    int size = MAX_SIZE;
+    if (size > sizeNum) size = sizeNum;
+
+    std::string newCommand =
+        "ssd.exe E " + std::to_string(lbaNum) + " " + std::to_string(size);
+    system(newCommand.c_str());
+
+    std::cout << newCommand << std::endl;
+
+    lbaNum += size;
+    sizeNum -= size;
+  }
+
+  return true;
+}
+
 bool ShellTest::excuteFlush(std::istringstream &iss) {
   std::string trashStr;
   iss >> trashStr;
@@ -158,5 +190,19 @@ bool ShellTest::checkValidValue(std::string &valueStr) {
         (valueChar < 'A' || valueChar > 'F') &&
         (valueChar < 'a' || valueChar > 'f'))
       return false;
+  return true;
+}
+
+bool ShellTest::checkValidSize(std::string &sizeStr) {
+  // long long 이상인 경우
+  if (sizeStr.length() >= 19) {
+    std::cout << err_too_big_size;
+    return false;
+  }
+  if (sizeStr[0] < '1' || sizeStr[0] > '9') return false;
+
+  for (char valueChar : sizeStr)
+    if (valueChar < '0' || valueChar > '9') return false;
+
   return true;
 }

--- a/TeamB_Shell/ShellTest.h
+++ b/TeamB_Shell/ShellTest.h
@@ -22,7 +22,9 @@ class ShellTest : public IShell {
   const std::string fullwrite_done = "[FullWrite] Done\n";
   const std::string invalid_command = "INVALID COMMAND\n";
   const std::string flush_done = "[Flush] Done\n";
+  const std::string err_too_big_size = "[Error] Size is too big\n";
   const int MAX_LBA = 100;
+  const int MAX_SIZE = 10;
 
  private:
   void printHelp(); 
@@ -30,9 +32,11 @@ class ShellTest : public IShell {
   bool excuteRead(std::istringstream &iss);
   bool excuteFullWrite(std::istringstream &iss);
   bool excuteFullRead(std::istringstream &iss);
+  bool excuteErase(std::istringstream &iss);
   bool excuteFlush(std::istringstream &iss);
   bool checkValidArgument(std::string &trashStr);
   bool checkValidLba(std::string &lbaStr);
   bool checkValidValue(std::string &valueStr);
+  bool checkValidSize(std::string &valueStr);
   const std::string output_file_name = "ssd_output.txt";
 };

--- a/TeamB_Shell/ShellTest_Test.cpp
+++ b/TeamB_Shell/ShellTest_Test.cpp
@@ -117,3 +117,30 @@ TEST_F(CommandFixture, FlushCmdInvaild) {
   shellTest.executeCommand("flush gogo\n");
   EXPECT_EQ(buffer.str(), shellTest.invalid_command);
 }
+
+TEST_F(CommandFixture, EraseValid) {
+  shellTest.executeCommand("erase 30 15\n");
+  std::string expected = "ssd.exe E 30 10\nssd.exe E 40 5\n";
+  EXPECT_EQ(buffer.str(), expected);
+}
+
+TEST_F(CommandFixture, EraseCmdInvalid) {
+  shellTest.executeCommand("erase 30 0xFFFFFFFF gogo\n");
+  EXPECT_EQ(buffer.str(), shellTest.invalid_command);
+}
+
+TEST_F(CommandFixture, EraseLbaInvalid) {
+  shellTest.executeCommand("erase a3 0xAAAABBBB\n");
+  EXPECT_EQ(buffer.str(), shellTest.invalid_command);
+}
+
+TEST_F(CommandFixture, EraseValueInvalid) {
+  shellTest.executeCommand("erase 30 0xFF\n");
+  EXPECT_EQ(buffer.str(), shellTest.invalid_command);
+}
+
+TEST_F(CommandFixture, EraseTooBigValueInvalid) {
+  shellTest.executeCommand("erase 30 10000000000000000000\n");
+  EXPECT_EQ(buffer.str(),
+            shellTest.err_too_big_size + shellTest.invalid_command);
+}


### PR DESCRIPTION
## 📌 PR 내용 요약
- Erase 기능 구현 및 TC 추가

## 🛠️ 주요 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- Erase 기능 구현
- Size 의 경우, 0 이하이거나, 숫자가 아니라면 ERROR / 1 이상이면 무조건 수행 (1~18자리)
- LBA 값이 0~99가 아닌 경우 ERROR

## 🧪 테스트 방법
TC 추가
- EraseValid
- EraseCmdInvalid
- EraseLbaInvalid
- EraseValueInvalid
- EraseTooBigValueInvalid

## ⚠️ 참고 사항
- 리뷰할 때 주의 깊게 봐줬으면 하는 부분
- 관련된 이슈나 PR 있으면 여기에 링크
