### PR TITLE
[윤제] Erase_Range 함수 구현 및 TC 추가 & Help Update

### DIFF
--- a/TeamB_Shell/ShellTest.cpp
+++ b/TeamB_Shell/ShellTest.cpp
@@ -25,6 +25,9 @@ void ShellTest::executeCommand(const std::string &input) {
   } else if (command == "erase") {
     if (!excuteErase(iss)) std::cout << invalid_command;
     return;
+  } else if (command == "erase_range") {
+    if (!excuteEraseRange(iss)) std::cout << invalid_command;
+    return;
   } else if (command == "flush") {
     if (!excuteFlush(iss)) std::cout << invalid_command;
     return;
@@ -35,22 +38,7 @@ void ShellTest::executeCommand(const std::string &input) {
   }
 }
 
-void ShellTest::printHelp() {
-  std::cout
-      << R"(Best Reviewers (A community of individuals who aspire to be the best reviewers) 
-- byeongun.ko [Team Leader]
-- yuz010.kim
-- yunje.kim	
-- hjy.park
-
-[Commands]
-- write LBA Value : Writes the specified Value to the given LBA.
-- read LBA : Reads the Value from the given LBA.
-- exit : Exits the Shell Test.
-- fullwrite Value : Writes the specified Value to all LBAs.
-- fullread : Reads values from all LBAs.
-)" << std::endl;
-}
+void ShellTest::printHelp() { std::cout << help_command << std::endl; }
 
 bool ShellTest::excuteWrite(std::istringstream &iss) {
   std::string lbaStr, valueStr, trashStr;
@@ -119,9 +107,7 @@ bool ShellTest::excuteErase(std::istringstream &iss) {
 
   if (!checkValidArgument(trashStr)) return false;
   if (!checkValidLba(lbaStr)) return false;
-  if (!checkValidSize(sizeStr)) {
-    return false;
-  }
+  if (!checkValidSize(sizeStr)) return false;
 
   long long sizeNum = std::stoll(sizeStr);
   int lbaNum = std::stoi(lbaStr);
@@ -133,9 +119,43 @@ bool ShellTest::excuteErase(std::istringstream &iss) {
         "ssd.exe E " + std::to_string(lbaNum) + " " + std::to_string(size);
     system(newCommand.c_str());
 
-    std::cout << newCommand << std::endl;
+    std::cout << erase_done << newCommand << std::endl;
 
     lbaNum += size;
+    sizeNum -= size;
+  }
+
+  return true;
+}
+
+bool ShellTest::excuteEraseRange(std::istringstream &iss) {
+  std::string startLbaStr, endLbaStr, trashStr;
+  iss >> startLbaStr >> endLbaStr >> trashStr;
+
+  if (!checkValidArgument(trashStr)) return false;
+  if (!checkValidLba(startLbaStr)) return false;
+  if (!checkValidLba(endLbaStr)) return false;
+
+  int startLbaNum = std::stoi(startLbaStr);
+  int endLbaNum = std::stoi(endLbaStr);
+
+  if (startLbaNum > endLbaNum) {
+    std::cout << err_start_bigger_than_end;
+    return false;
+  }
+
+  int sizeNum = endLbaNum - startLbaNum + 1;
+  while (sizeNum > 0) {
+    int size = MAX_SIZE;
+    if (size > sizeNum) size = sizeNum;
+
+    std::string newCommand =
+        "ssd.exe E " + std::to_string(startLbaNum) + " " + std::to_string(size);
+    system(newCommand.c_str());
+
+    std::cout << erase_done << newCommand << std::endl;
+
+    startLbaNum += size;
     sizeNum -= size;
   }
 

--- a/TeamB_Shell/ShellTest.h
+++ b/TeamB_Shell/ShellTest.h
@@ -27,6 +27,7 @@ class ShellTest : public IShell {
   bool excuteFullWrite(std::istringstream &iss);
   bool excuteFullRead(std::istringstream &iss);
   bool excuteErase(std::istringstream &iss);
+  bool excuteEraseRange(std::istringstream &iss);
   bool excuteFlush(std::istringstream &iss);
   bool checkValidArgument(std::string &trashStr);
   bool checkValidLba(std::string &lbaStr);

--- a/TeamB_Shell/ShellTest_Test.cpp
+++ b/TeamB_Shell/ShellTest_Test.cpp
@@ -121,8 +121,7 @@ TEST_F(CommandFixture, FlushCmdInvaild) {
 TEST_F(CommandFixture, EraseValid) {
   shellTest.executeCommand("erase 30 15\n");
   std::string expected =
-      "ssd.exe E 30 10\n"
-      "ssd.exe E 40 5\n";
+      erase_done + "ssd.exe E 30 10\n" + erase_done + "ssd.exe E 40 5\n";
   EXPECT_EQ(buffer.str(), expected);
 }
 
@@ -144,4 +143,33 @@ TEST_F(CommandFixture, EraseValueInvalid) {
 TEST_F(CommandFixture, EraseTooBigValueInvalid) {
   shellTest.executeCommand("erase 30 10000000000000000000\n");
   EXPECT_EQ(buffer.str(), err_too_big_size + invalid_command);
+}
+
+TEST_F(CommandFixture, EraseRange_Valid) {
+  shellTest.executeCommand("erase_range 21 42\n");
+  std::string expected = erase_done + "ssd.exe E 21 10\n" + erase_done +
+                         "ssd.exe E 31 10\n" + erase_done + "ssd.exe E 41 2\n";
+  EXPECT_EQ(buffer.str(), expected);
+}
+
+TEST_F(CommandFixture, EraseRange_Valid2) {
+  shellTest.executeCommand("erase_range 57 83\n");
+  std::string expected = erase_done + "ssd.exe E 57 10\n" + erase_done +
+                         "ssd.exe E 67 10\n" + erase_done + "ssd.exe E 77 7\n";
+  EXPECT_EQ(buffer.str(), expected);
+}
+
+TEST_F(CommandFixture, EraseRange_Cmd_Invalid) {
+  shellTest.executeCommand("erase_range 10 20 gogo\n");
+  EXPECT_EQ(buffer.str(), invalid_command);
+}
+
+TEST_F(CommandFixture, EraseRange_LBA_Invalid) {
+  shellTest.executeCommand("erase_range 30 102\n");
+  EXPECT_EQ(buffer.str(), invalid_command);
+}
+
+TEST_F(CommandFixture, EraseRange_startLBA_bigger_than_endLBA_Invalid) {
+  shellTest.executeCommand("erase_range 30 10\n");
+  EXPECT_EQ(buffer.str(), err_start_bigger_than_end + invalid_command);
 }

--- a/TeamB_Shell/define.h
+++ b/TeamB_Shell/define.h
@@ -3,9 +3,33 @@
 const std::string write_done = "[Write] Done\n";
 const std::string read_done = "[Read] ";
 const std::string fullwrite_done = "[FullWrite] Done\n";
-const std::string invalid_command = "INVALID COMMAND\n";
 const std::string flush_done = "[Flush] Done\n";
+const std::string erase_done = "[Erase] ";
+
+const std::string invalid_command = "INVALID COMMAND\n";
 const std::string err_too_big_size = "[Error] Size is too big\n";
+const std::string err_start_bigger_than_end =
+    "[Error] Start LBA bigger than End LBA\n";
+
 const int MAX_LBA = 100;
 const int MAX_SIZE = 10;
+
 const std::string output_file_name = "ssd_output.txt";
+
+const std::string help_command =
+    R"(Best Reviewers (A community of individuals who aspire to be the best reviewers) 
+- byeongun.ko [Team Leader]
+- yuz010.kim
+- yunje.kim	
+- hjy.park
+
+[Commands]
+- write LBA Value : Writes the specified Value to the given LBA.
+- read LBA : Reads the Value from the given LBA.
+- exit : Exits the Shell Test.
+- fullwrite Value : Writes the specified Value to all LBAs.
+- fullread : Reads values from all LBAs.
+- erase LBA Size : Erase from LBA to Size.
+- erase_range StartLBA EndLBA : Erase from between StartLBA and EndLBA.
+- flush : Executes all commands in the buffer.
+)";


### PR DESCRIPTION
## 📌 PR 내용 요약
- Erase_Range 함수 구현 및 TC 추가
- Help Update

## 🛠️ 주요 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- Erase_Range StartLBA End LBA: StartLBA ~ EndLBA 사이에 Erase 명령 수행
- LBA 값이 0~99 이외인 경우 ERROR
- Start LBA가 End LBA보다 큰 경우 ERROR

## 🧪 테스트 방법
TC 생성 및 PASS
- EraseRange_Valid: erase_range 21 42 결과값 TEST
- EraseRange_Valid2: erase_range 57 83 결과값 TEST
- EraseRange_Cmd_Invalid: Argument가 너무 많은 경우 ERROR
- EraseRange_LBA_Invalid: LBA값이 0~99 범위를 벗어나는 경우 ERROR
- EraseRange_startLBA_bigger_than_endLBA_Invalid: Start LBA가 End LBA보다 큰 경우 ERROR

## ⚠️ 참고 사항
- 리뷰할 때 주의 깊게 봐줬으면 하는 부분
- 관련된 이슈나 PR 있으면 여기에 링크
