### PR TITLE
[화영] Test 중에 Fail 나는 부분 없도록 수정. ..

### DIFF
--- a/TeamB_SSD/EraseCommand.cpp
+++ b/TeamB_SSD/EraseCommand.cpp
@@ -16,6 +16,11 @@ bool EraseCommand::execute() {
     return false;
   }
 
+  if (size > 10) {
+    ssd.saveOutputToFile(ERROR_SIZE);
+    size = 10;
+  }
+
   for (int startLBA = lba; startLBA < lba + size; ++startLBA) {
     if (ssd.isOutOfRange(startLBA)) {
       ssd.saveStorageToFile();

--- a/TeamB_SSD/SSD_Test.cpp
+++ b/TeamB_SSD/SSD_Test.cpp
@@ -67,9 +67,13 @@ TEST_F(CommandFixture, basic_SSD_test_Erase_0_10) {
 }
 
 TEST_F(CommandFixture, basic_SSD_test_Erase_95_10) {
-  executeAndExpectTRUE('E', 95, 10);
+  expectCommandFALSE('E', 95, 10);
 }
 
 TEST_F(CommandFixture, basic_SSD_test_Erase_100_10) {
   expectCommandFALSE('E', 100, 10);
+}
+
+TEST_F(CommandFixture, basic_SSD_test_Erase_0_20) {
+  executeAndExpectTRUE('E', 0, 20);
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- Test 중에 Fail 나는 부분 없도록 수정. 
-  erase 에서 size 가 10 보다 크면 ERROR_SIZE 에러를 ssd_ouput.txt 에 적고 sizes는 10까지만 erase 진행
- 
## 🛠️ 주요 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- SSD_Test.cpp : Test중에 Fail 나는 부분 없도록 수정 
- EraseCommand.cpp : erase 에서 size 가 10 보다 크면 ERROR_SIZE 에러를 ssd_ouput.txt 에 적고 sizes는 10까지만 erase 진행하도록 수정. 
- 
## 🧪 테스트 방법

## ⚠️ 참고 사항
