### PR TITLE
[윤제] log compression 기능 추가

### DIFF
--- a/TeamB_Shell/TeamB_Shell.vcxproj
+++ b/TeamB_Shell/TeamB_Shell.vcxproj
@@ -105,6 +105,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -119,6 +120,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/TeamB_Shell/define.h
+++ b/TeamB_Shell/define.h
@@ -1,5 +1,9 @@
 #pragma once
 #include <string>
+
+const int KB = 1024;
+const int LOG_MAX_SIZE = 10 * KB;
+const int FUNC_MAX_LEN = 30;
 const std::string write_done = "[Write] Done\n";
 const std::string read_done = "[Read] ";
 const std::string fullwrite_done = "[FullWrite] Done\n";

--- a/TeamB_Shell/define.h
+++ b/TeamB_Shell/define.h
@@ -4,6 +4,7 @@
 const int KB = 1024;
 const int LOG_MAX_SIZE = 10 * KB;
 const int FUNC_MAX_LEN = 30;
+
 const std::string write_done = "[Write] Done\n";
 const std::string read_done = "[Read] ";
 const std::string fullwrite_done = "[FullWrite] Done\n";

--- a/TeamB_Shell/logger.cpp
+++ b/TeamB_Shell/logger.cpp
@@ -14,8 +14,7 @@ void Logger::print(std::string funcName, std::string message) {
   std::ostringstream funcStream;
   funcStream << std::left << std::setw(FUNC_MAX_LEN) << funcName;
 
-  fs::path logPath = "latest.log";
-  std::ofstream logFile(logPath, std::ios::app);
+  std::ofstream logFile("latest.log", std::ios::app);
   if (logFile) {
     logFile << timestamp << " " << funcStream.str() << " : " << message
             << std::endl;
@@ -27,11 +26,11 @@ void Logger::print(std::string funcName, std::string message) {
 }
 
 void Logger::spiltLogFile() {
-  fs::path logPath = "latest.log";
+  fs::path fileName = "latest.log";
 
-  if (!fs::exists(logPath)) return;
+  if (!fs::exists(fileName)) return;
 
-  auto fileSize = fs::file_size(logPath);
+  auto fileSize = fs::file_size(fileName);
 
   if (fileSize <= LOG_MAX_SIZE) return;
 
@@ -41,9 +40,9 @@ void Logger::spiltLogFile() {
 
   std::ostringstream oss;
   oss << "until_" << std::put_time(&localTime, "%y%m%d_%Hh_%Mm_%Ss") << ".log";
-  fs::path newLogPath = oss.str();
+  fs::path newFileName = oss.str();
 
-  fs::rename(logPath, newLogPath);
+  fs::rename(fileName, newFileName);
 }
 
 void Logger::compressOldLogFiles() {
@@ -66,10 +65,10 @@ void Logger::compressOldLogFiles() {
             });
 
   for (int i = 1; i < logFiles.size(); i++) {
-    fs::path oldFileName = logFiles[i].path();
-    fs::path newFileName = oldFileName;
+    fs::path fileName = logFiles[i].path();
+    fs::path newFileName = fileName;
     newFileName.replace_extension(".zip");
 
-    fs::rename(oldFileName, newFileName);
+    fs::rename(fileName, newFileName);
   }
 }

--- a/TeamB_Shell/logger.h
+++ b/TeamB_Shell/logger.h
@@ -1,15 +1,17 @@
 #pragma once
 
-#include <cstdio>
-#include <ctime>
+#include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <string>
+#include <vector>
 
 #include "define.h"
 
 class Logger {
  public:
   void print(std::string funcName, std::string message);
-  void manageLog();
+
+ private:
+  void spiltLogFile();
+  void compressOldLogFiles();
 };


### PR DESCRIPTION
## 📌 PR 내용 요약
- log compression 기능 추가: untin_*.log 파일이 여러개 있으면, 최신 파일 1개만 남기고 확장자를 zip으로 변경
- KB 및 함수 최대길이를 define에 정의
- C++20을 사용하도록 프로젝트 설정 변경하여, C++17부터 사용할 수 있는 filesystem 헤더를 사용하여 코드 간결하게 리팩토링

## 🛠️ 주요 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- print: 로그 기록 함수
- spiltLogFile: 10KB가 넘는 경우, until_시간.log 형식으로 파일 이름 변경
- compressOldLogFiles: until_시간.log 형식의 파일이 여러개 있으면, 최신 파일 1개만 남기고 확장자를 .zip으로 변경

## 🧪 테스트 방법
- .log 파일들 생성하여 테스트
![image](https://github.com/user-attachments/assets/76096e5e-e148-4d30-b837-0b4fc49ed2ad)


## ⚠️ 참고 사항
- 리뷰할 때 주의 깊게 봐줬으면 하는 부분
- 관련된 이슈나 PR 있으면 여기에 링크
