### PR TITLE
[화영] read 실행할 때 buffer에값 있는 경우 buffer값읽어 들이도록 추가

### DIFF
--- a/TeamB_SSD/CommandBuffer.h
+++ b/TeamB_SSD/CommandBuffer.h
@@ -25,7 +25,9 @@ public:
   void reloadFromCommandFile2();
   void updateBufferFile(int index, const std::string& commandType, int lba, uint32_t dataOrSize);
 
-private:
+  bool getReadCommandBuffer(int lba, uint32_t& data);
+
+ private:
   void renameOrCreateFile(const std::string& oldFileName, const std::string& newFileName);
   void createFile(const std::string& newFileName);
   void initializeBufferFolder();

--- a/TeamB_SSD/EraseCommand.cpp
+++ b/TeamB_SSD/EraseCommand.cpp
@@ -7,23 +7,23 @@ EraseCommand::EraseCommand(VirtualSSD& ssd, int lba, int size)
 
 bool EraseCommand::execute() {
   if (ssd.isOutOfRange(lba)) {
-    ssd.saveOutputToFile(ERROR);
+    ssd.saveOutputToFile(MSG_ERROR);
     return false;
   }
 
   if (size <= 0) {
-    ssd.saveOutputToFile(ERROR_SIZE);
+    ssd.saveOutputToFile(MSG_ERROR_SIZE);
     return false;
   }
 
   if (size > 10) {
-    ssd.saveOutputToFile(ERROR_SIZE);
+    ssd.saveOutputToFile(MSG_ERROR_SIZE);
     size = 10;
   }
 
   for (int startLBA = lba; startLBA < lba + size; ++startLBA) {
     if (ssd.isOutOfRange(startLBA)) {
-      ssd.saveOutputToFile(ERROR_OUT_OF_RANGE);
+      ssd.saveOutputToFile(MSG_ERROR_OUT_OF_RANGE);
       return false;
     }
     ssd.setData(startLBA, 0);

--- a/TeamB_SSD/ReadCommand.cpp
+++ b/TeamB_SSD/ReadCommand.cpp
@@ -6,7 +6,7 @@ bool ReadCommand::execute() {
 
   std::stringstream ss;
   ss << "LBA " << lba << " 0x" << std::setfill('0') << std::setw(8)
-    << std::hex << std::uppercase << ssd.getData(lba);
+    << std::hex << std::uppercase << ssd.readData(lba);
 
   return ssd.saveOutputToFile(ss.str());
 }

--- a/TeamB_SSD/SSD_Test.cpp
+++ b/TeamB_SSD/SSD_Test.cpp
@@ -57,7 +57,7 @@ TEST_F(CommandFixture, basic_SSD_test_Read_3_TRUE) {
 }
 
 TEST_F(CommandFixture, basic_SSD_test_Read_3_OutOfRange) {
-  expectCommandFALSE('R', 103, 0x00000000);
+  expectCommandFALSE('R', 103, DEFAULT_VALUE);
 }
 
 TEST_F(CommandFixture, basic_SSD_test_Write_Wrong_lba_index) {
@@ -81,3 +81,7 @@ TEST_F(CommandFixture, basic_SSD_test_Erase_100_10) {
 TEST_F(CommandFixture, basic_SSD_test_Erase_0_20) {
   executeAndExpectTRUE('E', 0, 20);
 }
+
+ TEST_F(CommandFixture, basic_SSD_testR_Read_Buffer_102) {
+  executeAndExpectTRUE('R', 3, 0xAAAABBBB);
+ }

--- a/TeamB_SSD/TeamB_SSD.vcxproj
+++ b/TeamB_SSD/TeamB_SSD.vcxproj
@@ -111,6 +111,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/TeamB_SSD/TeamB_SSD.vcxproj.filters
+++ b/TeamB_SSD/TeamB_SSD.vcxproj.filters
@@ -31,12 +31,6 @@
     <ClCompile Include="SSD_Test.cpp">
       <Filter>리소스 파일\test</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
     <ClCompile Include="WriteCommand.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>

--- a/TeamB_SSD/VirtualSSD.cpp
+++ b/TeamB_SSD/VirtualSSD.cpp
@@ -26,6 +26,15 @@ void VirtualSSD::setData(int lba, uint32_t data) {
   storage[lba] = data;
 }
 
+uint32_t VirtualSSD::readData(int lba) {
+  // buffer에 read 하려는 값이 있는 경우 buffer에서 가지고 온다.
+  uint32_t data = DEFAULT_VALUE;
+  if (commandBuffer.getReadCommandBuffer(lba, data)) {
+    return data;
+  }
+  return getData(lba);
+}
+
 uint32_t VirtualSSD::getData(int lba) const {
   return storage[lba];
 }
@@ -81,7 +90,7 @@ bool VirtualSSD::saveOutputToFile(std::string outData) {
 
 bool VirtualSSD::isOutOfRange(int lba) {
   if (lba < 0 || lba >= MAX_RANGE_NUM) {
-    saveOutputToFile(ERROR);
+    saveOutputToFile(MSG_ERROR);
     return true;
   }
   return false;

--- a/TeamB_SSD/VirtualSSD.h
+++ b/TeamB_SSD/VirtualSSD.h
@@ -17,8 +17,8 @@ public:
 
   bool executeCommand(std::shared_ptr<ICommand> command);
   void setData(int lba, uint32_t data);
-  uint32_t getData(int lba) const;
-
+  //uint32_t getData(int lba) const;
+  uint32_t readData(int lba);
   bool saveStorageToFile();
   void loadStorageFromFile();
 
@@ -39,4 +39,6 @@ private:
   const std::string out_file;
 
   CommandBuffer commandBuffer;
+
+  uint32_t getData(int lba) const;
 };

--- a/TeamB_SSD/define.h
+++ b/TeamB_SSD/define.h
@@ -1,8 +1,8 @@
 #pragma once
 
-static constexpr const char* ERROR = "ERROR";
-static constexpr const char* ERROR_SIZE = "ERROR_SIZE";
-static constexpr const char* ERROR_OUT_OF_RANGE = "ERROR_OUT_OF_RANGE";
+const std::string MSG_ERROR = "ERROR";
+const std::string MSG_ERROR_SIZE = "ERROR_SIZE";
+const std::string MSG_ERROR_OUT_OF_RANGE = "ERROR_OUT_OF_RANGE";
 
-static constexpr const int MAX_RANGE_NUM = 100;
-static constexpr const int DEFAULT_VALUE = 0x00000000;
+const int MAX_RANGE_NUM = 100;
+const int DEFAULT_VALUE = 0x00000000;


### PR DESCRIPTION
## 📌 PR 내용 요약
- read 실행할 때 buffer에값 있는 경우 buffer값읽어 들이도록 추가

## 🛠️ 주요 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- SSD_Test.cpp : buffer 실행 후 read 명령어 테스트 추가.
- define.h : 상수변수들을 string으로 변경하고 ERROR 변수명들 앞에 MSG 추가. 
- VirtualSSD.cpp : buffer와 sdd_nand.txt 파일에서 읽어 오는 부분 구분하도록 readData 함수 추가.
 
## 🧪 테스트 방법

## ⚠️ 참고 사항
 * 파일 변경점이 없는데 스타일 때문에 줄 바꿈이 되어버렸습니다. ㅡㅡ 