### PR TITLE
[병운] [fix] only call when flush, read command execute

### DIFF
--- a/TeamB_SSD/VirtualSSD.cpp
+++ b/TeamB_SSD/VirtualSSD.cpp
@@ -16,9 +16,11 @@ VirtualSSD::VirtualSSD(const std::string& nand, const std::string& out)
 bool VirtualSSD::executeCommand(std::shared_ptr<ICommand> command) {
   if (auto writeCommand = dynamic_cast<WriteCommand*>(command.get())) {
     commandBuffer.addCommand(command);
+    return true;
   }
   else if (auto eraseCommand = dynamic_cast<EraseCommand*>(command.get())) {
     commandBuffer.addCommand(command);
+    return true;
   }
   return command->execute();
 }


### PR DESCRIPTION
	- write , erase cmd push into command buffer
Signed-off-by: bw.ko <kbwcap@gmail.com>

## 📌 PR 내용 요약
- Write , Erase 는 command buffer를 통해 수행되고 다른 command는 바로 수행된다. 
- 
## 🛠️ 주요 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- fix wrong operation
## 🧪 테스트 방법
- 어떤 테스트를 했는지, 어떻게 확인했는지 써줘요
- 예: `make test` 실행 결과 캡처 또는 설명

## ⚠️ 참고 사항
- 리뷰할 때 주의 깊게 봐줬으면 하는 부분
- 관련된 이슈나 PR 있으면 여기에 링크
