### PR TITLE
[화영] BugFix : CommandBuffer.cpp

### DIFF
--- a/TeamB_SSD/CommandBuffer.cpp
+++ b/TeamB_SSD/CommandBuffer.cpp
@@ -216,7 +216,7 @@ bool CommandBuffer::canMerge(int id1, int size1, int id2, int size2) {
   int end2 = id2 + size2 - 1;
 
   // 겹치거나 붙어 있는 경우
-  return !(end1 < start2 - 1 || end2 < start1 - 1);
+  return !(end1 < start2 || end2 < start1);
 }
 
 void CommandBuffer::addCommand(std::shared_ptr<ICommand> command) {

--- a/TeamB_SSD/CommandBuffer.cpp
+++ b/TeamB_SSD/CommandBuffer.cpp
@@ -161,7 +161,8 @@ std::shared_ptr<ICommand> CommandBuffer::setIgnoreMergeCommmand(
               my_max(rEraseCommand->getLBA() + rEraseCommand->getSize() - 1,
                        e->getLBA() + e->getSize() - 1);
           int mergedSize = mergedEnd - mergedLBA + 1;
-
+          mergedSize = mergedSize > 10 ? 10 : mergedSize;
+          
           command = std::make_shared<EraseCommand>(ssd, mergedLBA, mergedSize);
           merged = true;
         }


### PR DESCRIPTION
 ## 📌 PR 내용 요약
- canMerge 함수에서 End 값에 -1을 삭제 하였습니다. 

## 🛠️ 주요 변경 사항
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 업데이트

변경된 파일이나 함수 중심으로 간단히 정리해줘요:
- CommandBuffer.cpp 
 =>  -1을 하면 E 0, 10   /    E 10, 10 두개의 명령어를 Merge 해버리는 버그가 발견 되어서 -1 삭제함.

## 🧪 테스트 방법
- 어떤 테스트를 했는지, 어떻게 확인했는지 써줘요
- 예: `make test` 실행 결과 캡처 또는 설명

## ⚠️ 참고 사항
- 리뷰할 때 주의 깊게 봐줬으면 하는 부분
- 관련된 이슈나 PR 있으면 여기에 링크
